### PR TITLE
Remove accidental "\" in heading.

### DIFF
--- a/index.src.html
+++ b/index.src.html
@@ -405,7 +405,7 @@ The audience of this document is general:
   third parties are found to be abusing the functionality.
 
   <h3 id="private-browsing">
-    How does this specification work in the context of a user agent’s Private \
+    How does this specification work in the context of a user agent’s Private
     Browsing or "incognito" mode?
   </h3>
 


### PR DESCRIPTION
I assume this "\\" isn't actually supposed to be there (it shows up in the rendered html as well).

