### PR TITLE
merge questions 2.1 and 2.8

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -126,6 +126,29 @@ See also
 
 * [[DESIGN-PRINCIPLES#priority-of-constituencies]]
 
+When answering this question, please consider each of these four possible
+areas of information disclosure / sharing.
+
+For the below sub-questions,
+please take the term *potentially identifying information*
+to mean information that describes the browser user,
+distinct from others who use the same browser version.
+Examples of such *potentially identifying information* include information
+about the browser user's environment (e.g., operating system configuration,
+browser configuration, hardware capabilities), and the user's prior activities
+and interests (e.g., browsing history, purchasing preferences, personal
+characteristics).
+
+1.  What information does your spec expose to the **first party** that
+    the **first party** cannot currently easily determine.
+2.  What information does your spec expose to **third parties** that
+    **third parties** cannot currently easily determine.
+3.  What *potentially identifying information* does your spec expose to the
+    **first party** that the **first party** can already access (i.e., what
+    identifying information does your spec duplicate or mirror).
+4.  What *potentially identifying information* does your spec expose to
+    **third parties** that **third parties** can already access.
+
 <h3 class=question id="minimum-data">
   Is this specification exposing the minimum amount of information necessary
   to power its features?
@@ -139,6 +162,13 @@ why does it do so?
 See also
 
 * [[#data-minimization]]
+
+<p class=example>
+Content Security Policy [[CSP]] unintentionally exposed redirect targets
+cross-origin by allowing one origin to infer details about another origin
+through violation reports (see [[HOMAKOV]]). The working group eventually
+mitigated the risk by reducing a policy's granularity after a redirect.
+</p>
 
 <h3 class=question id="personal-data">
   How does this specification deal with personal information,
@@ -488,31 +518,6 @@ Even relatively short lived data, like the battery status, may be able to
 serve as an identifier [[OLEJNIK-BATTERY]].
 </p>
 
-<h3 class=question id="other-data">
-  What data does this specification expose to an origin?  Please also
-  document what data is identical to data exposed by other features, in the
-  same or different contexts.
-</h3>
-
-As noted above in [[#sop-violations]], the [=same-origin policy=] is an
-important security barrier that new features need to carefully consider.
-If a specification exposes details about another origin's state, or allows
-POST or GET requests to be made to another origin, the consequences can be
-severe.
-
-<p class=example>
-Content Security Policy [[CSP]] unintentionally exposed redirect targets
-cross-origin by allowing one origin to infer details about another origin
-through violation reports (see [[HOMAKOV]]). The working group
-mitigated the risk by reducing a policy's granularity after a redirect.
-</p>
-
-<p class=example> Beacon [[BEACON]] allows an origin to send POST
-requests to an endpoint on another origin. The working group concluded
-that this feature did not add any new attack surface above and beyond
-what normal form submission entails, so no extra mitigation was
-necessary.  </p>
-
 <h3 class=question id="string-to-script">
   Does this specification enable new script execution/loading mechanisms?
 </h3>
@@ -810,7 +815,7 @@ purposes:
   Same-Origin Policy Violations
 </h3>
 
-The <dfn>same-origin policy</dfn> is the cornerstone of security on the web;
+The **same-origin policy** is the cornerstone of security on the web;
 one origin should not have direct access to another origin's data (the policy
 is more formally defined in Section 3 of [[RFC6454]]). A corollary to this
 policy is that an origin should not have direct access to data that isn't

--- a/questionnaire.markdown
+++ b/questionnaire.markdown
@@ -18,20 +18,17 @@ For your convenience, a copy of the questionnaire's questions is quoted here in 
 >     platform to origins?
 > 07. Does this specification allow an origin access to sensors on a user’s
 >     device
-> 08. What data does this specification expose to an origin?  Please also
->     document what data is identical to data exposed by other features, in the
->     same or different contexts.
-> 09. Does this specification enable new script execution/loading mechanisms?
-> 10. Does this specification allow an origin to access other devices?
-> 11. Does this specification allow an origin some measure of control over a user
+> 08. Does this specification enable new script execution/loading mechanisms?
+> 09. Does this specification allow an origin to access other devices?
+> 10. Does this specification allow an origin some measure of control over a user
 >     agent's native UI?
-> 12. What temporary identifiers might this specification create or expose
+> 11. What temporary identifiers might this specification create or expose
 >     to the web?
-> 13. How does this specification distinguish between behavior in first-party and
+> 12. How does this specification distinguish between behavior in first-party and
 >     third-party contexts?
-> 14. How does this specification work in the context of a user agent’s Private
+> 13. How does this specification work in the context of a user agent’s Private
 >     Browsing or "incognito" mode?
-> 15. Does this specification have both "Security Considerations" and "Privacy
->     Considerations" sections?
-> 16. Does this specification allow downgrading default security characteristics?
-> 17. What should this questionnaire have asked?
+> 14. Does this specification have a "Security Considerations" and "Privacy
+>     Considerations" section?
+> 15. Does this specification allow downgrading default security characteristics?
+> 16. What should this questionnaire have asked?


### PR DESCRIPTION
fixes issue #97

Since 2.8 and 2.1 cover a lot of the same subject matter, this PR moves the implied-enumeration from 2.8 into 2.1


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/security-questionnaire/pull/100.html" title="Last updated on Dec 8, 2021, 9:50 PM UTC (2e3e988)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/security-questionnaire/100/7df4dce...2e3e988.html" title="Last updated on Dec 8, 2021, 9:50 PM UTC (2e3e988)">Diff</a>