### PR TITLE
point to a specific section of rfc3552

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -670,8 +670,8 @@ implementers and web developers.
 
 [[RFC6973]] is an excellent resource to consult when considering
 privacy impacts of your specification, particularly Section 7 of
-RFC6983.  [[RFC3552]] provides general advice as to writing Security
-Consideration sections.
+RFC6973.  [[RFC3552]] provides general advice as to writing Security
+Consideration sections, and Section 5 of RFC3552 has specific requirements.
 
 Generally, these sections should contain clear descriptions of the
 privacy and security risks the specification introduces.  It is also


### PR DESCRIPTION
and fix a typo


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/security-questionnaire/pull/110.html" title="Last updated on Nov 10, 2020, 4:34 PM UTC (05ed527)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/security-questionnaire/110/afd2334...05ed527.html" title="Last updated on Nov 10, 2020, 4:34 PM UTC (05ed527)">Diff</a>