### PR TITLE
Add non-"fully active" document question

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -779,24 +779,24 @@ and to advertise a simple mechanism to exit fullscreen (typically the `Esc` key)
 </div>
 
 <h3 class=question id="non-fully-active">
-  How does your feature handle non-"[=Document/fully active=]" documents?
+  How does your feature handle non-"fully active" documents?
 </h3>
 
 After a user navigated away from a document,
 the document might stay around in a non-"[=Document/fully active=]" state,
 and might be reused when the user navigates back to the entry holding the document.
 From the user’s perspective,
-the non-"[=Document/fully active=]" document is already discarded
+the non-[=Document/fully active=] document is already discarded
 and thus should not get updates/events that happen after they navigated away from it,
 especially privacy-sensitive information (e.g. geolocation).
 Also, as a document might be reused even after navigation,
 be aware that tying something to a document’s lifetime
 also means reusing it after navigations.
 If this is not desirable,
-consider listening to changes to the "[=Document/fully active=]" state
+consider listening to changes to the [=Document/fully active=] state
 and doing cleanup as necessary.
 
-For more detailed guidance on how to handle non-"[=Document/fully active=]" documents,
+For more detailed guidance on how to handle non-[=Document/fully active=] documents,
 see [[DESIGN-PRINCIPLES#non-fully-active]].
 
 <div class=example>

--- a/index.bs
+++ b/index.bs
@@ -782,9 +782,9 @@ and to advertise a simple mechanism to exit fullscreen (typically the `Esc` key)
   How does your feature handle non-"fully active" documents?
 </h3>
 
-After a user navigated away from a document,
+After a user navigates away from a document,
 the document might stay around in a non-"[=Document/fully active=]" state,
-and might be reused when the user navigates back to the entry holding the document.
+and might be reused when the user navigates back to the document.
 From the user’s perspective,
 the non-[=Document/fully active=] document is already discarded
 and thus should not get updates/events that happen after they navigated away from it,

--- a/index.bs
+++ b/index.bs
@@ -778,6 +778,41 @@ to display an overlay which informs the user that they have entered fullscreen,
 and to advertise a simple mechanism to exit fullscreen (typically the `Esc` key).
 </div>
 
+<h3 class=question id="non-fully-active">
+  How does your feature handle non-"[=Document/fully active=]" documents?
+</h3>
+
+After a user navigated away from a document,
+the document might stay around in a non-"[=Document/fully active=]" state,
+and might be reused when the user navigates back to the entry holding the document.
+From the user’s perspective,
+the non-"[=Document/fully active=]" document is already discarded
+and thus should not get updates/events that happen after they navigated away from it,
+especially privacy-sensitive information (e.g. geolocation).
+Also, as a document might be reused even after navigation,
+be aware that tying something to a document’s lifetime
+also means reusing it after navigations.
+If this is not desirable,
+consider listening to changes to the "[=Document/fully active=]" state
+and doing cleanup as necessary.
+
+For more detailed guidance on how to handle non-"[=Document/fully active=]" documents,
+see [[DESIGN-PRINCIPLES#non-fully-active]].
+
+<div class=example>
+Screen WakeLock API [releases the wake lock](https://w3c.github.io/screen-wake-lock/#handling-document-loss-of-full-activity)
+when a document becomes no longer fully active.
+</div>
+<div class=example>
+[=Sticky activation=] is determined by the "last activation timestamp",
+which is tied to a document.
+This means after a user triggers activation once on a document,
+the document will have sticky activation forever,
+even after the user navigated away and back to it again.
+Whether this should actually be reset when full activity is lost or not
+is still [under discussion](https://github.com/whatwg/html/issues/6588).
+</div>
+
 <h3 class=question id="missing-questions">
   What should this questionnaire have asked?
 </h3>

--- a/questionnaire.markdown
+++ b/questionnaire.markdown
@@ -37,4 +37,5 @@ For your convenience, a copy of the questionnaire's questions is quoted here in 
 >      Considerations" sections?
 > 17.  Do features in your specification enable origins to downgrade default
 >      security protections?
-> 18.  What should this questionnaire have asked?
+> 18.  How does your feature handle non-"[=Document/fully active=]" documents?
+> 19.  What should this questionnaire have asked?

--- a/questionnaire.markdown
+++ b/questionnaire.markdown
@@ -37,5 +37,5 @@ For your convenience, a copy of the questionnaire's questions is quoted here in 
 >      Considerations" sections?
 > 17.  Do features in your specification enable origins to downgrade default
 >      security protections?
-> 18.  How does your feature handle non-"[=Document/fully active=]" documents?
+> 18.  How does your feature handle non-"fully active" documents?
 > 19.  What should this questionnaire have asked?


### PR DESCRIPTION
As discussed in https://github.com/w3ctag/design-reviews/issues/628, there are some privacy considerations that might be worth pointing out in the Security & Privacy Questionnaire.

This change adds a question on non-"fully active" document handling to the questionnaire.

cc @hober @domenic @fergal

Note that there's another PR for the "Web Platform Design Principles" doc at https://github.com/w3ctag/design-principles/pull/317


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rakina/security-questionnaire/pull/128.html" title="Last updated on Aug 11, 2021, 3:40 AM UTC (9a18d70)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/security-questionnaire/128/dcf934a...rakina:9a18d70.html" title="Last updated on Aug 11, 2021, 3:40 AM UTC (9a18d70)">Diff</a>