### PR TITLE
point to rendered template

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -94,7 +94,7 @@ from the [Technical Architecture Group (TAG)](https://www.w3.org/2001/tag/),
 please provide the TAG with answers
 to the questions in this document.
 [This Markdown
-template](https://raw.githubusercontent.com/w3ctag/security-questionnaire/main/questionnaire.markdown)
+template](https://github.com/w3ctag/security-questionnaire/blob/main/questionnaire.markdown)
 may be useful when doing so.
 
 


### PR DESCRIPTION
The current link to the template points to raw markdown in which the template appears as a quoted block (making it inconvenient to copy/paste).

Change the link to one where the markdown will be rendered so that the template can be copied easily.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/fergald/security-questionnaire/pull/142.html" title="Last updated on May 12, 2022, 8:22 AM UTC (ea9c18c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/security-questionnaire/142/dc1a7f4...fergald:ea9c18c.html" title="Last updated on May 12, 2022, 8:22 AM UTC (ea9c18c)">Diff</a>