### PR TITLE
Use 'mode' consistently in private-browsing

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -656,8 +656,8 @@ Most browsers implement a private browsing or incognito mode,
 though they vary significantly in what functionality they provide and
 how that protection is described to users [[WU-PRIVATE-BROWSING]].
 
-One commonality is that they provide a different set of state
-than the browser's 'normal' state.
+One commonality is that they provide a different set of mode
+than the browser's 'normal' mode.
 
 Do features in this spec provide information that would allow for the
 correlation of a single user's activity across normal and private


### PR DESCRIPTION
For the most part, the question and description uses "mode" with the exception of this sentence that uses "state". Unless the use of the term "state" was intentional, it may be better to use "mode" instead.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/csarven/security-questionnaire/pull/150.html" title="Last updated on Jan 17, 2023, 4:04 PM UTC (3d15f3c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/security-questionnaire/150/dc1a7f4...csarven:3d15f3c.html" title="Last updated on Jan 17, 2023, 4:04 PM UTC (3d15f3c)">Diff</a>