### PR TITLE
Improve the link to Web Bluetooth privacy considerations

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -612,7 +612,7 @@ involve the user with a permission request of some kind.
 
 <p class=example>
 Likewise, the Web Bluetooth [[WEB-BLUETOOTH]] has an extensive discussion of
-such issues in [[WEB-BLUETOOTH#security-and-privacy]], which is worth
+such issues in [[WEB-BLUETOOTH#privacy]], which is worth
 reading as an example for similar work.
 </p>
 


### PR DESCRIPTION
The "Security and privacy considerations" section was split, and the `#security-and-privacy` anchor wound up pointing to an empty Security Considerations section. 🤷


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3ctag/security-questionnaire/pull/164.html" title="Last updated on Sep 5, 2024, 8:33 PM UTC (3ffa7f0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/security-questionnaire/164/73a0469...3ffa7f0.html" title="Last updated on Sep 5, 2024, 8:33 PM UTC (3ffa7f0)">Diff</a>