### PR TITLE
Fix a claim that disconnecting an iframe causes it to load a document.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -811,7 +811,7 @@ For more detailed guidance on how to handle BFCached documents,
 see [[DESIGN-PRINCIPLES#non-fully-active]] and the [Supporting BFCached Documents](https://w3ctag.github.io/bfcache-guide/) guide.
 
 Note: It is possible for a document to become non-[=Document/fully active=] for other reasons not related to BFcaching,
-such as when the iframe holding the document gets disconnected.
+such as when the iframe holding the document [=becomes disconnected=].
 Our advice is that all non-[=Document/fully active=] documents should be treated the same way.
 The only difference is that BFCached documents might become [=Document/fully active=] again,
 whereas documents in detached iframes will stay inactive forever.
@@ -863,10 +863,10 @@ users at risk include:
 <h3 class=question id="non-fully-active">
   What happens when a document that uses your feature gets disconnected?
 </h3>
-If the iframe element containing a document gets disconnected,
+If the iframe element containing a document [=becomes disconnected=],
 the document will no longer be [=Document/fully active=].
 The document will never become fully active again,
-because if the iframe element gets disconnected, it will load a new document.
+because if the iframe element [=becomes connected=] again, it will load a new document.
 The document is gone from the user's perspective,
 and should be treated as such by your feature as well.
 You may follow the guidelines for <a href="bfcache">BFCache</a> mentioned above,


### PR DESCRIPTION
Also link to the definition of "disconnected".

The original text comes from #144. @rakina / @domenic, is this fix correct?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/security-questionnaire/pull/165.html" title="Last updated on Sep 5, 2024, 10:21 PM UTC (4e24c70)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/security-questionnaire/165/87ca58b...jyasskin:4e24c70.html" title="Last updated on Sep 5, 2024, 10:21 PM UTC (4e24c70)">Diff</a>