### PR TITLE
Make questionnaire.markdown convenient for copying into an explainer.

### DIFF
--- a/generate-markdown.py
+++ b/generate-markdown.py
@@ -15,10 +15,10 @@ class MarkdownGenerator:
                 line = line.lstrip()
                 if self.first_line_in_question:
                     self.qnum += 1
-                    self.prefix = "> %02d. " % self.qnum
+                    self.prefix = "%02d. " % self.qnum
                     self.first_line_in_question = False
                 print(self.prefix, line, end='', file=outfile)
-                self.prefix = ">     "
+                self.prefix = "    "
             else:
                 self.in_question = False
         elif line.startswith("<h3 class=question id="):
@@ -28,9 +28,11 @@ class MarkdownGenerator:
     def generate_markdown(self, infile=sys.stdin, outfile=sys.stdout):
         print("""# [Self-Review Questionnaire: Security and Privacy](https://w3ctag.github.io/security-questionnaire/)
 
-This questionnaire has [moved](https://w3ctag.github.io/security-questionnaire/).
+The full questionnaire is at https://w3ctag.github.io/security-questionnaire/.
 
-For your convenience, a copy of the questionnaire's questions is quoted here in Markdown, so you can easily include your answers in an [explainer](https://github.com/w3ctag/w3ctag.github.io/blob/master/explainers.md).
+For your convenience, a copy of the questionnaire's questions is included here in Markdown, so you can easily include your answers in an [explainer](https://github.com/w3ctag/w3ctag.github.io/blob/master/explainers.md).
+
+---
 """, file=outfile)
         [self.process_line(line, outfile) for line in infile]
 

--- a/questionnaire.markdown
+++ b/questionnaire.markdown
@@ -1,44 +1,46 @@
 # [Self-Review Questionnaire: Security and Privacy](https://w3ctag.github.io/security-questionnaire/)
 
-This questionnaire has [moved](https://w3ctag.github.io/security-questionnaire/).
+The full questionnaire is at https://w3ctag.github.io/security-questionnaire/.
 
-For your convenience, a copy of the questionnaire's questions is quoted here in Markdown, so you can easily include your answers in an [explainer](https://github.com/w3ctag/w3ctag.github.io/blob/master/explainers.md).
+For your convenience, a copy of the questionnaire's questions is included here in Markdown, so you can easily include your answers in an [explainer](https://github.com/w3ctag/w3ctag.github.io/blob/master/explainers.md).
 
-> 01.  What information does this feature expose,
->      and for what purposes?
-> 02.  Do features in your specification expose the minimum amount of information
->      necessary to implement the intended functionality?
-> 03.  Do the features in your specification expose personal information,
->      personally-identifiable information (PII), or information derived from
->      either?
-> 04.  How do the features in your specification deal with sensitive information?
-> 05.  Does data exposed by your specification carry related but distinct
->      information that may not be obvious to users?
-> 06.  Do the features in your specification introduce state
->      that persists across browsing sessions?
-> 07.  Do the features in your specification expose information about the
->      underlying platform to origins?
-> 08.  Does this specification allow an origin to send data to the underlying
->      platform?
-> 09.  Do features in this specification enable access to device sensors?
-> 10.  Do features in this specification enable new script execution/loading
->      mechanisms?
-> 11.  Do features in this specification allow an origin to access other devices?
-> 12.  Do features in this specification allow an origin some measure of control over
->      a user agent's native UI?
-> 13.  What temporary identifiers do the features in this specification create or
->      expose to the web?
-> 14.  How does this specification distinguish between behavior in first-party and
->      third-party contexts?
-> 15.  How do the features in this specification work in the context of a browser’s
->      Private Browsing or Incognito mode?
-> 16.  Does this specification have both "Security Considerations" and "Privacy
->      Considerations" sections?
-> 17.  Do features in your specification enable origins to downgrade default
->      security protections?
-> 18.  What happens when a document that uses your feature is kept alive in BFCache
->      (instead of getting destroyed) after navigation, and potentially gets reused
->      on future navigations back to the document?
-> 19.  What happens when a document that uses your feature gets disconnected?
-> 20.  Does your feature allow sites to learn about the users use of assistive technology?
-> 21.  What should this questionnaire have asked?
+---
+
+01.  What information does this feature expose,
+     and for what purposes?
+02.  Do features in your specification expose the minimum amount of information
+     necessary to implement the intended functionality?
+03.  Do the features in your specification expose personal information,
+     personally-identifiable information (PII), or information derived from
+     either?
+04.  How do the features in your specification deal with sensitive information?
+05.  Does data exposed by your specification carry related but distinct
+     information that may not be obvious to users?
+06.  Do the features in your specification introduce state
+     that persists across browsing sessions?
+07.  Do the features in your specification expose information about the
+     underlying platform to origins?
+08.  Does this specification allow an origin to send data to the underlying
+     platform?
+09.  Do features in this specification enable access to device sensors?
+10.  Do features in this specification enable new script execution/loading
+     mechanisms?
+11.  Do features in this specification allow an origin to access other devices?
+12.  Do features in this specification allow an origin some measure of control over
+     a user agent's native UI?
+13.  What temporary identifiers do the features in this specification create or
+     expose to the web?
+14.  How does this specification distinguish between behavior in first-party and
+     third-party contexts?
+15.  How do the features in this specification work in the context of a browser’s
+     Private Browsing or Incognito mode?
+16.  Does this specification have both "Security Considerations" and "Privacy
+     Considerations" sections?
+17.  Do features in your specification enable origins to downgrade default
+     security protections?
+18.  What happens when a document that uses your feature is kept alive in BFCache
+     (instead of getting destroyed) after navigation, and potentially gets reused
+     on future navigations back to the document?
+19.  What happens when a document that uses your feature gets disconnected?
+20.  Does your feature allow sites to learn about the users use of assistive technology?
+21.  What should this questionnaire have asked?


### PR DESCRIPTION
Fixes #172: Without this change, users had to manually remove the `> ` prefixes.
