### PR TITLE
Link to Lukasz' specific analysis on visited links.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1430,8 +1430,8 @@ spec:indexeddb-3; type:attribute; text:indexedDB
       "authors": [ "Egor Homakov" ]
   },
   "OLEJNIK-ALS": {
-    "href": "https://blog.lukaszolejnik.com/privacy-of-ambient-light-sensors/",
-    "title": "Privacy analysis of Ambient Light Sensors",
+    "href": "https://blog.lukaszolejnik.com/stealing-sensitive-browser-data-with-the-w3c-ambient-light-sensor-api/",
+    "title": "Stealing sensitive browser data with the W3C Ambient Light Sensor API",
     "publisher": "Lukasz Olejnik",
     "authors": [ "Lukasz Olejnik" ]
   },


### PR DESCRIPTION
This is meant to fix #174 by @lflores-ms, by linking to the article that shows the `:visited` attack. Another way to fix it might be to generalize the claim about Ambient Light to include the potential attacks described on the main page. Thoughts?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/security-questionnaire/pull/178.html" title="Last updated on Nov 19, 2024, 8:44 PM UTC (67f55dc)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3ctag/security-questionnaire/178/7ae3bb8...jyasskin:67f55dc.html" title="Last updated on Nov 19, 2024, 8:44 PM UTC (67f55dc)">Diff</a>