### PR TITLE
Update the boilerplate to try to pass Pubrules.

### DIFF
--- a/copyright.include
+++ b/copyright.include
@@ -1,3 +1,3 @@
-<a href="http://creativecommons.org/publicdomain/zero/1.0/" rel="license"><img alt="CC0" title="CC0" no-autosize src="cc0-80x15.png"></a> To the extent
+<a href="http://creativecommons.org/publicdomain/zero/1.0/" rel="license"><img alt="CC0" height="15" src="cc0-80x15.png" title="CC0" width="80"></a> To the extent
 possible under law, the editors have waived all copyright and related or neighboring rights to this work.
-This document is also made available under the <a href="http://www.w3.org/Consortium/Legal/2015/copyright-software-and-document" rel="license">W3C Software and Document License</a>.
+This document is also made available under the <a href="https://www.w3.org/copyright/software-license-2023/" rel="license">W3C Software and Document License</a>.

--- a/status.include
+++ b/status.include
@@ -1,6 +1,6 @@
 <p><em>This section describes the status of this document at the time of its publication. A list of current W3C publications and the latest revision of this technical report can be found in the <a href="https://www.w3.org/TR/">W3C technical reports index</a> at https://www.w3.org/TR/.</em></p>
 
-<p>This document was published by the <a href="https://www.w3.org/groups/other/tag">Technical Architecture Group</a>, the <a href="https://www.w3.org/groups/ig/privacy">Privacy Interest Group</a>, and the <a href="https://www.w3.org/groups/ig/security/">Security Interest Group</a> as a Group Note using the <a href="https://www.w3.org/2021/Process-20211102/#recs-and-notes">Note track</a>.</p>
+<p>This document was published by the <a href="https://www.w3.org/groups/other/tag">Technical Architecture Group</a>, the <a href="https://www.w3.org/groups/wg/privacy">Privacy Working Group</a>, and the <a href="https://www.w3.org/groups/ig/security/">Security Interest Group</a> as a Group Note using the Note track.</p>
 
   <p>Group Notes are not endorsed by <abbr title="World Wide Web Consortium">W3C</abbr> nor its Members. </p>
 
@@ -20,19 +20,8 @@
     <a href="https://github.com/[REPOSITORY]/">GitHub repository</a>.
   </p>
 
-  <p data-deliverer="34270,52497">
-    This document was produced by groups operating under the <a
-    href="https://www.w3.org/Consortium/Patent-Policy/"><abbr title="World Wide
-    Web Consortium">W3C</abbr> Patent Policy</a>. The <abbr title="World Wide Web
-    Consortium">W3C</abbr> maintains a <a
-    href="https://www.w3.org/2004/01/pp-impl/52497/status"
-    rel="disclosure">public list of any patent disclosures</a> made in
-    connection with PING deliverables; that page also includes
-    instructions for disclosing a patent.
+  <p data-deliverer="34270,160680,49310">
+    The <a href="https://www.w3.org/policies/patent-policy/">W3C Patent Policy</a> does not carry any licensing requirements or commitments on this document.
   </p>
 
-  <p>
-    This document is governed by the <a id="w3c_process_revision"
-    href="https://www.w3.org/2021/Process-20211102/">2 November 2021 W3C
-    Process Document</a>. 
-  </p>
+  <p>This document is governed by the <a id="w3c_process_revision" href="https://www.w3.org/policies/process/20231103/">03 November 2023 W3C Process Document</a>. </p>


### PR DESCRIPTION
This fixes the pubrules errors in https://github.com/w3ctag/security-questionnaire/actions/runs/12676032694/job/35328328868 except for one about the copyright, which https://github.com/w3c/specberus/pull/1905 should fix. Tested with https://www.w3.org/pubrules/.