### PR TITLE
Embed the markdown template into the main questionnaire.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -1326,6 +1326,16 @@ requirements in specifications.  For example, in [[DOTY-GEOLOCATION]], it was
 found that none of the studied websites informed users of their privacy
 practices before the site prompted for location.
 
+# Appendix A: Markdown Template # {#template}
+
+See this rendered at
+[https://github.com/w3c/security-questionnaire/blob/main/questionnaire.markdown](https://github.com/w3c/security-questionnaire/blob/main/questionnaire.markdown).
+
+<pre class=include-code>
+path: questionnaire.markdown
+highlight: markdown
+</pre>
+
 <h2 id="acknowledgements" class="no-num">Acknowledgements</h2>
 
 <!-- Current TAG participants who would otherwise be ackked are


### PR DESCRIPTION
@miketaylr reported that this change would have prevented him from missing the existence of the markdown file. I don't have a strong opinion about the ordering relative to the Acknowledgements section or whether to call it a "Markdown Template" or something else.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):
#template
    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/security-questionnaire/pull/191.html#template" title="Last updated on Apr 14, 2025, 6:13 PM UTC (df4ea6c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/security-questionnaire/191/12d5b07...jyasskin:df4ea6c.html" title="Last updated on Apr 14, 2025, 6:13 PM UTC (df4ea6c)">Diff</a>